### PR TITLE
Fix Ent Trail detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ The plugin tracks totem states using game varbits:
 - Animal assignments
 
 ### Known Ent Trail IDs
-- 55115
-- 55116
+- 57115
+- 57116
 
 If you discover additional Ent Trail IDs, please report them!
 

--- a/src/main/java/net/brolard/valetotems/ValeTotemsTrailsOverlay.java
+++ b/src/main/java/net/brolard/valetotems/ValeTotemsTrailsOverlay.java
@@ -2,12 +2,22 @@ package net.brolard.valetotems;
 
 import javax.inject.Inject;
 
-import net.runelite.api.*;
+import net.runelite.api.Client;
+import net.runelite.api.GameObject;
+import net.runelite.api.NPC;
+import net.runelite.api.ObjectComposition;
+import net.runelite.api.Perspective;
+import net.runelite.api.Tile;
+import net.runelite.api.TileObject;
 import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayPriority;
+import net.runelite.api.gameval.AnimationID;
+import net.runelite.api.gameval.NpcID;
+import net.runelite.api.gameval.ObjectID;
 
 import java.awt.*;
 import java.util.Arrays;
@@ -20,8 +30,27 @@ public class ValeTotemsTrailsOverlay extends Overlay
     private final ValeTotems plugin;
     private final ValeTotemsConfig config;
 
-    // Known Ent Trail IDs
-    private static final Set<Integer> ENT_TRAIL_IDS = new HashSet<>(Arrays.asList(55115, 55116));
+    // Known Ent Trail IDs (game objects spawned as the ent walks)
+    private static final Set<Integer> ENT_TRAIL_IDS = new HashSet<>(Arrays.asList(57115, 57116));
+
+    // Locations the ent admires when performing its worship animation
+    private static final Set<Integer> ADMIRE_OBJECT_IDS = new HashSet<>(Arrays.asList(
+            ObjectID.ENT_TOTEMS_ADMIRE_LOC_1,
+            ObjectID.ENT_TOTEMS_ADMIRE_LOC_2,
+            ObjectID.ENT_TOTEMS_ADMIRE_LOC_3
+    ));
+
+    // Ent NPC IDs
+    private static final Set<Integer> ENT_NPC_IDS = new HashSet<>(Arrays.asList(
+            NpcID.ENT_TOTEMS_ENT,
+            NpcID.ENT_TOTEMS_ENT_BUFFED
+    ));
+
+    // Worship animation IDs
+    private static final Set<Integer> ENT_WORSHIP_ANIMS = new HashSet<>(Arrays.asList(
+            AnimationID.NPC_ENT_WORSHIP_01,
+            AnimationID.NPC_ENT_WORSHIP_02
+    ));
 
     @Inject
     public ValeTotemsTrailsOverlay(Client client, ValeTotems plugin, ValeTotemsConfig config)
@@ -46,6 +75,8 @@ public class ValeTotemsTrailsOverlay extends Overlay
         Tile[][][] tiles = client.getScene().getTiles();
         int z = client.getPlane();
 
+        Set<TileObject> admireObjects = new HashSet<>();
+
         for (int x = 0; x < 104; x++)
         {
             for (int y = 0; y < 104; y++)
@@ -56,37 +87,33 @@ public class ValeTotemsTrailsOverlay extends Overlay
                     continue;
                 }
 
-                GroundObject groundObject = tile.getGroundObject();
-                if (groundObject != null && isEntTrail(groundObject))
+                // Check all tile objects for ent trails or admire objects
+                for (TileObject obj : getTileObjects(tile))
                 {
-                    highlightGroundObject(graphics, groundObject);
+                    if (isEntTrail(obj))
+                    {
+                        highlightEntTrail(graphics, obj);
+                    }
+
+                    if (ADMIRE_OBJECT_IDS.contains(obj.getId()))
+                    {
+                        admireObjects.add(obj);
+                    }
                 }
             }
         }
 
+        highlightAdmireObjects(graphics, admireObjects);
+
         return null;
     }
 
-    private boolean isEntTrail(GroundObject groundObject)
+    private boolean isEntTrail(TileObject object)
     {
-        // First check if the ID matches
-        if (!ENT_TRAIL_IDS.contains(groundObject.getId()))
-        {
-            return false;
-        }
-
-        // Then verify the name to be extra sure
-        ObjectComposition comp = client.getObjectDefinition(groundObject.getId());
-        if (comp == null || comp.getName() == null)
-        {
-            return false;
-        }
-
-        // Must be exactly "Ent Trail" (case insensitive to be safe)
-        return comp.getName().equalsIgnoreCase("Ent Trail");
+        return object != null && ENT_TRAIL_IDS.contains(object.getId());
     }
 
-    private void highlightGroundObject(Graphics2D graphics, GroundObject groundObject)
+    private void highlightEntTrail(Graphics2D graphics, TileObject groundObject)
     {
         LocalPoint lp = groundObject.getLocalLocation();
         if (lp == null)
@@ -108,5 +135,101 @@ public class ValeTotemsTrailsOverlay extends Overlay
         // Fill with translucent green
         graphics.setColor(new Color(0, 255, 0, 30));
         graphics.fill(poly);
+    }
+
+    private void highlightAdmireObjects(Graphics2D graphics, Set<TileObject> objects)
+    {
+        if (objects.isEmpty())
+        {
+            return;
+        }
+
+        for (NPC npc : client.getNpcs())
+        {
+            if (!ENT_NPC_IDS.contains(npc.getId()))
+            {
+                continue;
+            }
+
+            if (!ENT_WORSHIP_ANIMS.contains(npc.getAnimation()))
+            {
+                continue;
+            }
+
+            TileObject nearest = null;
+            int bestDist = Integer.MAX_VALUE;
+            WorldPoint npcWp = npc.getWorldLocation();
+
+            for (TileObject obj : objects)
+            {
+                int dist = npcWp.distanceTo(obj.getWorldLocation());
+                if (dist < bestDist)
+                {
+                    bestDist = dist;
+                    nearest = obj;
+                }
+            }
+
+            if (nearest != null)
+            {
+                highlightTileObject(graphics, nearest);
+            }
+        }
+    }
+
+    private void highlightTileObject(Graphics2D graphics, TileObject object)
+    {
+        LocalPoint lp = object.getLocalLocation();
+        if (lp == null)
+        {
+            return;
+        }
+
+        Polygon poly = Perspective.getCanvasTilePoly(client, lp);
+        if (poly == null)
+        {
+            return;
+        }
+
+        graphics.setColor(new Color(0, 255, 255, 100));
+        graphics.setStroke(new BasicStroke(2));
+        graphics.draw(poly);
+
+        graphics.setColor(new Color(0, 255, 255, 30));
+        graphics.fill(poly);
+    }
+
+    private Iterable<TileObject> getTileObjects(Tile tile)
+    {
+        Set<TileObject> objs = new HashSet<>();
+
+        if (tile.getGroundObject() != null)
+        {
+            objs.add(tile.getGroundObject());
+        }
+
+        if (tile.getDecorativeObject() != null)
+        {
+            objs.add(tile.getDecorativeObject());
+        }
+
+        if (tile.getWallObject() != null)
+        {
+            objs.add(tile.getWallObject());
+        }
+
+        GameObject[] gos = tile.getGameObjects();
+        if (gos != null)
+        {
+            for (GameObject go : gos)
+            {
+                if (go != null)
+                {
+                    objs.add(go);
+                }
+            }
+        }
+
+        return objs;
     }
 }


### PR DESCRIPTION
## Summary
- use gameval ObjectID/AnimationID/NpcID imports
- detect Ent Trails among any tile objects instead of just ground objects
- highlight Admired objects near worshipping ent

## Testing
- `./gradlew test` *(fails: Could not resolve net.runelite:client)*

------
https://chatgpt.com/codex/tasks/task_e_6883366e5de8832d831c232cba7574a9